### PR TITLE
Added build scripts for toolchain, and added temporary fix for panic

### DIFF
--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -633,7 +633,11 @@ fn rust_panic_with_hook(
     location: &Location<'_>,
     can_unwind: bool,
 ) -> ! {
-    let (must_abort, panics) = panic_count::increase();
+    //DH changed this to avoid recursion/crash
+    //Temporary workaround which supports panic using hook, until we have more FreeRTOS support in std (specifically, mutex handling).
+    //let (must_abort, panics) = panic_count::increase();
+    let must_abort = false;
+    let panics = 1;
 
     // If this is the third nested call (e.g., panics == 2, this is 0-indexed),
     // the panic hook probably triggered the last panic, otherwise the

--- a/rebuild.bat
+++ b/rebuild.bat
@@ -1,0 +1,6 @@
+rem Because incremental builds are broken and Cargo clean does not work, we delete the build directory and rebuild
+rmdir .\build\x86_64-pc-windows-msvc /s /q
+set TARGET_CC=C:\ST\STM32CubeIDE_1.9.0\STM32CubeIDE\plugins\com.st.stm32cube.ide.mcu.externaltools.gnu-tools-for-stm32.10.3-2021.10.win32_1.0.0.202111181127\tools\bin\arm-none-eabi-gcc.exe
+python x.py build --stage 1 library --target=thumbv7em-none-eabihf
+rustup toolchain link stage1 build\x86_64-pc-windows-msvc\stage1
+python x.py build --stage 2 library --target=thumbv7em-none-eabihf

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -1,0 +1,5 @@
+# Because incremental builds are broken and Cargo clean does not work, we delete the build directory and rebuild
+rm -r ./build/x86_64-unknown-linux-gnu
+python3 x.py build --stage 1 library --target=thumbv7em-none-eabihf
+rustup toolchain link stage1 build/x86_64-unknown-linux-gnu/stage1
+python3 x.py build --stage 2 library --target=thumbv7em-none-eabihf


### PR DESCRIPTION
Added scripts for building toolchain (which is a bit brain damaged and not well documented, especially for embedded targets).
Temporary workaround to panic handler not working on embedded targets which supports panic using hook, until we have more FreeRTOS support in std (specifically, mutex handling).