### PR TITLE
Remove temporary recursion check workaround

### DIFF
--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -633,11 +633,7 @@ fn rust_panic_with_hook(
     location: &Location<'_>,
     can_unwind: bool,
 ) -> ! {
-    //DH changed this to avoid recursion/crash
-    //Temporary workaround which supports panic using hook, until we have more FreeRTOS support in std (specifically, mutex handling).
-    //let (must_abort, panics) = panic_count::increase();
-    let must_abort = false;
-    let panics = 1;
+    let (must_abort, panics) = panic_count::increase();
 
     // If this is the third nested call (e.g., panics == 2, this is 0-indexed),
     // the panic hook probably triggered the last panic, otherwise the


### PR DESCRIPTION
Removed workaround for panic recursion check failure. Now that mutex and other std features have been properly implemented, the original recursion check code can be reinstated.