### PR TITLE
MVPN1238: Added TCP functions and fixed socket error handling

### DIFF
--- a/library/std/src/sys_common/net.rs
+++ b/library/std/src/sys_common/net.rs
@@ -398,7 +398,9 @@ impl TcpListener {
         // On Windows, this allows rebinding sockets which are actively in use,
         // which allows “socket hijacking”, so we explicitly don't set it here.
         // https://docs.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse
-        #[cfg(not(windows))]
+        //
+        // On FreeRTOS + LwIP, SO_REUSEADDR is not supported with the standard configuration (so don't do it!)
+        #[cfg(not(any(windows, target_os = "freertos")))]
         setsockopt(&sock, c::SOL_SOCKET, c::SO_REUSEADDR, 1 as c_int)?;
 
         // Bind our new socket


### PR DESCRIPTION
Added accept, listen, getsockopt, setsockopt, getpeername, getsockname implementations. A full TCP client or server application using std is now possible.
Fixed socket error handling (now correctly returns Err(something) from failed socket calls. However, further work is needed to get errno from FreeRTOS.
Suppressed implicit SO_REUSEADDR setsockopt call from within bind for FreeRTOS. LwIP does not support this option by default.
