### PR TITLE
Mvpn 2207 connect timeout

### DIFF
--- a/library/std/src/sys/freertos/net.rs
+++ b/library/std/src/sys/freertos/net.rs
@@ -388,7 +388,7 @@ impl Socket {
         // Does not correspond to a single OS call.
         // We put the socket in nonblocking mode and call connect(). Then we poll it during the timeout period.
         // It will either succeed to connect, or time out.
-        // At any point, an error other then in progress/would block aborts the process.
+        // At any point, an error other than in progress/would block aborts the process.
 
         // Given a SocketAddr, we must make a netc::sockaddr to give to LwIP. The structs are not the same!
         let mut sin_family: u8;

--- a/library/std/src/sys/freertos/os.rs
+++ b/library/std/src/sys/freertos/os.rs
@@ -5,13 +5,23 @@ use crate::fmt;
 use crate::io;
 use crate::marker::PhantomData;
 use crate::path::{self, PathBuf};
+use core::ffi::c_int;
 
 // FreeRTOS does not have a filesystem unless FreeRTOS-plus-FAT is used.
 // For compatibility with 'vanilla' FreeRTOS, and since we don't rely on a filesystem, these functions are stubbed and raise
 // errors.
 
+pub const pdFREERTOS_ERRNO_EWOULDBLOCK: i32 = 11;
+pub const LwIP_ERRNO_EINPROGRESS: i32 = 115;
+pub const pdFREERTOS_ERRNO_ETIMEDOUT: i32 = 116;
+
 pub fn errno() -> i32 {
-    0
+    // Link with FreeRTOS' global errno (we don't need to expose this at the top level)
+    extern "C" {
+        #[no_mangle]
+        static errno: c_int;
+    }
+    unsafe { errno }
 }
 
 pub fn error_string(_errno: i32) -> String {


### PR DESCRIPTION
Implemented connect_timeout()
Implemented get_errno() for FreeRTOS, which was needed for connect_timeout. More work needed on this to declare a full set of constants and to implement error_string()
Fixed a bug in set_nonblocking, which passed a pointer to bool down to underlying lwip function. Unfortunately this was interpreting it as a pointer to int, which meant values surrounding the bool would influence the result.