### PR TITLE
Rearrange std net for FreeRTOS to expose socket features (needed for socket2 integration)

### DIFF
--- a/library/std/src/os/freertos/io/mod.rs
+++ b/library/std/src/os/freertos/io/mod.rs
@@ -1,0 +1,59 @@
+//! Windows-specific extensions to general I/O primitives.
+//!
+//! Just like raw pointers, raw Windows handles and sockets point to resources
+//! with dynamic lifetimes, and they can dangle if they outlive their resources
+//! or be forged if they're created from invalid values.
+//!
+//! This module provides three types for representing raw handles and sockets
+//! with different ownership properties: raw, borrowed, and owned, which are
+//! analogous to types used for representing pointers:
+//!
+//! | Type                   | Analogous to |
+//! | ---------------------- | ------------ |
+//! | [`RawHandle`]          | `*const _`   |
+//! | [`RawSocket`]          | `*const _`   |
+//! |                        |              |
+//! | [`BorrowedHandle<'a>`] | `&'a _`      |
+//! | [`BorrowedSocket<'a>`] | `&'a _`      |
+//! |                        |              |
+//! | [`OwnedHandle`]        | `Box<_>`     |
+//! | [`OwnedSocket`]        | `Box<_>`     |
+//!
+//! Like raw pointers, `RawHandle` and `RawSocket` values are primitive values.
+//! And in new code, they should be considered unsafe to do I/O on (analogous
+//! to dereferencing them). Rust did not always provide this guidance, so
+//! existing code in the Rust ecosystem often doesn't mark `RawHandle` and
+//! `RawSocket` usage as unsafe. Once the `io_safety` feature is stable,
+//! libraries will be encouraged to migrate, either by adding `unsafe` to APIs
+//! that dereference `RawHandle` and `RawSocket` values, or by using to
+//! `BorrowedHandle`, `BorrowedSocket`, `OwnedHandle`, or `OwnedSocket`.
+//!
+//! Like references, `BorrowedHandle` and `BorrowedSocket` values are tied to a
+//! lifetime, to ensure that they don't outlive the resource they point to.
+//! These are safe to use. `BorrowedHandle` and `BorrowedSocket` values may be
+//! used in APIs which provide safe access to any system call except for
+//! `CloseHandle`, `closesocket`, or any other call that would end the
+//! dynamic lifetime of the resource without ending the lifetime of the
+//! handle or socket.
+//!
+//! `BorrowedHandle` and `BorrowedSocket` values may be used in APIs which
+//! provide safe access to `DuplicateHandle` and `WSADuplicateSocketW` and
+//! related functions, so types implementing `AsHandle`, `AsSocket`,
+//! `From<OwnedHandle>`, or `From<OwnedSocket>` should not assume they always
+//! have exclusive access to the underlying object.
+//!
+//! Like boxes, `OwnedHandle` and `OwnedSocket` values conceptually own the
+//! resource they point to, and free (close) it when they are dropped.
+//!
+//! [`BorrowedHandle<'a>`]: crate::os::windows::io::BorrowedHandle
+//! [`BorrowedSocket<'a>`]: crate::os::windows::io::BorrowedSocket
+
+#![stable(feature = "rust1", since = "1.0.0")]
+
+mod raw;
+
+#[stable(feature = "rust1", since = "1.0.0")]
+pub use raw::*;
+
+#[cfg(test)]
+mod tests;

--- a/library/std/src/os/freertos/io/mod.rs
+++ b/library/std/src/os/freertos/io/mod.rs
@@ -1,52 +1,11 @@
-//! Windows-specific extensions to general I/O primitives.
+//! FreeRTOS-specific extensions to general I/O primitives.
 //!
-//! Just like raw pointers, raw Windows handles and sockets point to resources
-//! with dynamic lifetimes, and they can dangle if they outlive their resources
-//! or be forged if they're created from invalid values.
+//! RawSocket is a raw socket handle. It is not safe for general use, as wrapping
+//! types like Socket look after unique ownership and closing the socket on drop.
 //!
-//! This module provides three types for representing raw handles and sockets
-//! with different ownership properties: raw, borrowed, and owned, which are
-//! analogous to types used for representing pointers:
-//!
-//! | Type                   | Analogous to |
-//! | ---------------------- | ------------ |
-//! | [`RawHandle`]          | `*const _`   |
-//! | [`RawSocket`]          | `*const _`   |
-//! |                        |              |
-//! | [`BorrowedHandle<'a>`] | `&'a _`      |
-//! | [`BorrowedSocket<'a>`] | `&'a _`      |
-//! |                        |              |
-//! | [`OwnedHandle`]        | `Box<_>`     |
-//! | [`OwnedSocket`]        | `Box<_>`     |
-//!
-//! Like raw pointers, `RawHandle` and `RawSocket` values are primitive values.
-//! And in new code, they should be considered unsafe to do I/O on (analogous
-//! to dereferencing them). Rust did not always provide this guidance, so
-//! existing code in the Rust ecosystem often doesn't mark `RawHandle` and
-//! `RawSocket` usage as unsafe. Once the `io_safety` feature is stable,
-//! libraries will be encouraged to migrate, either by adding `unsafe` to APIs
-//! that dereference `RawHandle` and `RawSocket` values, or by using to
-//! `BorrowedHandle`, `BorrowedSocket`, `OwnedHandle`, or `OwnedSocket`.
-//!
-//! Like references, `BorrowedHandle` and `BorrowedSocket` values are tied to a
-//! lifetime, to ensure that they don't outlive the resource they point to.
-//! These are safe to use. `BorrowedHandle` and `BorrowedSocket` values may be
-//! used in APIs which provide safe access to any system call except for
-//! `CloseHandle`, `closesocket`, or any other call that would end the
-//! dynamic lifetime of the resource without ending the lifetime of the
-//! handle or socket.
-//!
-//! `BorrowedHandle` and `BorrowedSocket` values may be used in APIs which
-//! provide safe access to `DuplicateHandle` and `WSADuplicateSocketW` and
-//! related functions, so types implementing `AsHandle`, `AsSocket`,
-//! `From<OwnedHandle>`, or `From<OwnedSocket>` should not assume they always
-//! have exclusive access to the underlying object.
-//!
-//! Like boxes, `OwnedHandle` and `OwnedSocket` values conceptually own the
-//! resource they point to, and free (close) it when they are dropped.
-//!
-//! [`BorrowedHandle<'a>`]: crate::os::windows::io::BorrowedHandle
-//! [`BorrowedSocket<'a>`]: crate::os::windows::io::BorrowedSocket
+//! RawSocket is used internally to pass temporary references to socket functions
+//! It can also be used as an intermediary type if converting between different
+//! socket representations.
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/library/std/src/os/freertos/io/raw.rs
+++ b/library/std/src/os/freertos/io/raw.rs
@@ -1,6 +1,6 @@
 //! freertos-specific extensions to general I/O primitives.
 
-#![stable(feature = "rust1", since = "1.0.0")]
+#![stable(feature = "lwip_network", since = "1.64.0")]
 
 use crate::fs;
 use crate::io;
@@ -28,7 +28,7 @@ pub struct RawSocket {
 */
 
 /// Extracts raw sockets.
-#[stable(feature = "rust1", since = "1.0.0")]
+#[stable(feature = "lwip_network", since = "1.64.0")]
 pub trait AsRawSocket {
     /// Extracts the raw socket.
     ///
@@ -39,12 +39,12 @@ pub trait AsRawSocket {
     ///
     /// However, borrowing is not strictly required. See [`AsSocket::as_socket`]
     /// for an API which strictly borrows a socket.
-    #[stable(feature = "rust1", since = "1.0.0")]
+    #[stable(feature = "lwip_network", since = "1.64.0")]
     fn as_raw_socket(&self) -> RawSocket;
 }
 
 /// Creates I/O objects from raw sockets.
-#[stable(feature = "from_raw_os", since = "1.1.0")]
+#[stable(feature = "lwip_network", since = "1.64.0")]
 pub trait FromRawSocket {
     /// Constructs a new I/O object from the specified raw socket.
     ///
@@ -65,13 +65,13 @@ pub trait FromRawSocket {
     ///   - be a socket that may be freed via [`closesocket`].
     ///
     /// [`closesocket`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-closesocket
-    #[stable(feature = "from_raw_os", since = "1.1.0")]
+    #[stable(feature = "lwip_network", since = "1.64.0")]
     unsafe fn from_raw_socket(sock: RawSocket) -> Self;
 }
 
 /// A trait to express the ability to consume an object and acquire ownership of
 /// its raw `SOCKET`.
-#[stable(feature = "into_raw_os", since = "1.4.0")]
+#[stable(feature = "lwip_network", since = "1.64.0")]
 pub trait IntoRawSocket {
     /// Consumes this object, returning the raw underlying socket.
     ///
@@ -82,25 +82,25 @@ pub trait IntoRawSocket {
     /// However, transferring ownership is not strictly required. Use a
     /// `Into<Socket>::into` implementation for an API which strictly
     /// transfers ownership.
-    #[stable(feature = "into_raw_os", since = "1.4.0")]
+    #[stable(feature = "lwip_network", since = "1.64.0")]
     fn into_raw_socket(self) -> RawSocket;
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
+#[stable(feature = "lwip_network", since = "1.64.0")]
 impl AsRawSocket for net::TcpStream {
     #[inline]
     fn as_raw_socket(&self) -> RawSocket {
         self.as_inner().socket().as_raw_socket()
     }
 }
-#[stable(feature = "rust1", since = "1.0.0")]
+#[stable(feature = "lwip_network", since = "1.64.0")]
 impl AsRawSocket for net::TcpListener {
     #[inline]
     fn as_raw_socket(&self) -> RawSocket {
         self.as_inner().socket().as_raw_socket()
     }
 }
-#[stable(feature = "rust1", since = "1.0.0")]
+#[stable(feature = "lwip_network", since = "1.64.0")]
 impl AsRawSocket for net::UdpSocket {
     #[inline]
     fn as_raw_socket(&self) -> RawSocket {
@@ -108,7 +108,7 @@ impl AsRawSocket for net::UdpSocket {
     }
 }
 
-#[stable(feature = "from_raw_os", since = "1.1.0")]
+#[stable(feature = "lwip_network", since = "1.64.0")]
 impl FromRawSocket for net::TcpStream {
     #[inline]
     unsafe fn from_raw_socket(raw_socket: RawSocket) -> net::TcpStream {
@@ -117,7 +117,7 @@ impl FromRawSocket for net::TcpStream {
         net::TcpStream::from_inner(sys_common::net::TcpStream::from_inner(sock))
     }
 }
-#[stable(feature = "from_raw_os", since = "1.1.0")]
+#[stable(feature = "lwip_network", since = "1.64.0")]
 impl FromRawSocket for net::TcpListener {
     #[inline]
     unsafe fn from_raw_socket(raw_socket: RawSocket) -> net::TcpListener {
@@ -125,7 +125,7 @@ impl FromRawSocket for net::TcpListener {
         net::TcpListener::from_inner(sys_common::net::TcpListener::from_inner(sock))
     }
 }
-#[stable(feature = "from_raw_os", since = "1.1.0")]
+#[stable(feature = "lwip_network", since = "1.64.0")]
 impl FromRawSocket for net::UdpSocket {
     #[inline]
     unsafe fn from_raw_socket(raw_socket: RawSocket) -> net::UdpSocket {
@@ -134,7 +134,7 @@ impl FromRawSocket for net::UdpSocket {
     }
 }
 
-#[stable(feature = "into_raw_os", since = "1.4.0")]
+#[stable(feature = "lwip_network", since = "1.64.0")]
 impl IntoRawSocket for net::TcpStream {
     #[inline]
     fn into_raw_socket(self) -> RawSocket {
@@ -144,7 +144,7 @@ impl IntoRawSocket for net::TcpStream {
     }
 }
 
-#[stable(feature = "into_raw_os", since = "1.4.0")]
+#[stable(feature = "lwip_network", since = "1.64.0")]
 impl IntoRawSocket for net::TcpListener {
     #[inline]
     fn into_raw_socket(self) -> RawSocket {
@@ -154,7 +154,7 @@ impl IntoRawSocket for net::TcpListener {
     }
 }
 
-#[stable(feature = "into_raw_os", since = "1.4.0")]
+#[stable(feature = "lwip_network", since = "1.64.0")]
 impl IntoRawSocket for net::UdpSocket {
     #[inline]
     fn into_raw_socket(self) -> RawSocket {

--- a/library/std/src/os/freertos/io/raw.rs
+++ b/library/std/src/os/freertos/io/raw.rs
@@ -1,0 +1,165 @@
+//! freertos-specific extensions to general I/O primitives.
+
+#![stable(feature = "rust1", since = "1.0.0")]
+
+use crate::fs;
+use crate::io;
+use crate::net;
+#[cfg(doc)]
+use crate::os::freertos::io::{AsHandle, AsSocket};
+use crate::ptr;
+use crate::sys;
+use crate::sys::net::Socket;
+use crate::sys_common::{self, AsInner, FromInner, IntoInner};
+use core::ffi::c_int;
+
+/// Raw SOCKETs.
+// RawSocket holds the same state variables as Socket. It is useful as a clone of Socket, which does not call lwip_close
+// when dropped.
+#[stable(feature = "lwip_network", since = "1.64.0")]
+
+pub type RawSocket = c_int;
+/*
+#[derive(Debug, Copy, Clone)]
+pub struct RawSocket {
+    pub socket_handle: c_int, //### TODO: access function for this.
+    pub socket_type: c_int,   //### TODO: access function for this.
+}
+*/
+
+/// Extracts raw sockets.
+#[stable(feature = "rust1", since = "1.0.0")]
+pub trait AsRawSocket {
+    /// Extracts the raw socket.
+    ///
+    /// This function is typically used to **borrow** an owned socket.
+    /// When used in this way, this method does **not** pass ownership of the
+    /// raw socket to the caller, and the socket is only guaranteed
+    /// to be valid while the original object has not yet been destroyed.
+    ///
+    /// However, borrowing is not strictly required. See [`AsSocket::as_socket`]
+    /// for an API which strictly borrows a socket.
+    #[stable(feature = "rust1", since = "1.0.0")]
+    fn as_raw_socket(&self) -> RawSocket;
+}
+
+/// Creates I/O objects from raw sockets.
+#[stable(feature = "from_raw_os", since = "1.1.0")]
+pub trait FromRawSocket {
+    /// Constructs a new I/O object from the specified raw socket.
+    ///
+    /// This function is typically used to **consume ownership** of the socket
+    /// given, passing responsibility for closing the socket to the returned
+    /// object. When used in this way, the returned object
+    /// will take responsibility for closing it when the object goes out of
+    /// scope.
+    ///
+    /// However, consuming ownership is not strictly required. Use a
+    /// `From<OwnedSocket>::from` implementation for an API which strictly
+    /// consumes ownership.
+    ///
+    /// # Safety
+    ///
+    /// The `socket` passed in must:
+    ///   - be a valid an open socket,
+    ///   - be a socket that may be freed via [`closesocket`].
+    ///
+    /// [`closesocket`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-closesocket
+    #[stable(feature = "from_raw_os", since = "1.1.0")]
+    unsafe fn from_raw_socket(sock: RawSocket) -> Self;
+}
+
+/// A trait to express the ability to consume an object and acquire ownership of
+/// its raw `SOCKET`.
+#[stable(feature = "into_raw_os", since = "1.4.0")]
+pub trait IntoRawSocket {
+    /// Consumes this object, returning the raw underlying socket.
+    ///
+    /// This function is typically used to **transfer ownership** of the underlying
+    /// socket to the caller. When used in this way, callers are then the unique
+    /// owners of the socket and must close it once it's no longer needed.
+    ///
+    /// However, transferring ownership is not strictly required. Use a
+    /// `Into<Socket>::into` implementation for an API which strictly
+    /// transfers ownership.
+    #[stable(feature = "into_raw_os", since = "1.4.0")]
+    fn into_raw_socket(self) -> RawSocket;
+}
+
+#[stable(feature = "rust1", since = "1.0.0")]
+impl AsRawSocket for net::TcpStream {
+    #[inline]
+    fn as_raw_socket(&self) -> RawSocket {
+        self.as_inner().socket().as_raw_socket()
+    }
+}
+#[stable(feature = "rust1", since = "1.0.0")]
+impl AsRawSocket for net::TcpListener {
+    #[inline]
+    fn as_raw_socket(&self) -> RawSocket {
+        self.as_inner().socket().as_raw_socket()
+    }
+}
+#[stable(feature = "rust1", since = "1.0.0")]
+impl AsRawSocket for net::UdpSocket {
+    #[inline]
+    fn as_raw_socket(&self) -> RawSocket {
+        self.as_inner().socket().as_raw_socket()
+    }
+}
+
+#[stable(feature = "from_raw_os", since = "1.1.0")]
+impl FromRawSocket for net::TcpStream {
+    #[inline]
+    unsafe fn from_raw_socket(raw_socket: RawSocket) -> net::TcpStream {
+        let sock = Socket::from_raw_socket(raw_socket);
+        //let sock: Socket = sys::net::Socket::from_inner(thing);
+        net::TcpStream::from_inner(sys_common::net::TcpStream::from_inner(sock))
+    }
+}
+#[stable(feature = "from_raw_os", since = "1.1.0")]
+impl FromRawSocket for net::TcpListener {
+    #[inline]
+    unsafe fn from_raw_socket(raw_socket: RawSocket) -> net::TcpListener {
+        let sock = Socket::from_raw_socket(raw_socket);
+        net::TcpListener::from_inner(sys_common::net::TcpListener::from_inner(sock))
+    }
+}
+#[stable(feature = "from_raw_os", since = "1.1.0")]
+impl FromRawSocket for net::UdpSocket {
+    #[inline]
+    unsafe fn from_raw_socket(raw_socket: RawSocket) -> net::UdpSocket {
+        let sock = Socket::from_raw_socket(raw_socket);
+        net::UdpSocket::from_inner(sys_common::net::UdpSocket::from_inner(sock))
+    }
+}
+
+#[stable(feature = "into_raw_os", since = "1.4.0")]
+impl IntoRawSocket for net::TcpStream {
+    #[inline]
+    fn into_raw_socket(self) -> RawSocket {
+        let thing = self.into_inner().into_socket().into_inner();
+        thing //.into_raw_socket()
+        //self.into_inner().into_socket().as_raw()
+    }
+}
+
+#[stable(feature = "into_raw_os", since = "1.4.0")]
+impl IntoRawSocket for net::TcpListener {
+    #[inline]
+    fn into_raw_socket(self) -> RawSocket {
+        //self.into_inner().into_socket().as_raw()
+        let thing = self.into_inner().into_socket().into_inner();
+        thing
+    }
+}
+
+#[stable(feature = "into_raw_os", since = "1.4.0")]
+impl IntoRawSocket for net::UdpSocket {
+    #[inline]
+    fn into_raw_socket(self) -> RawSocket {
+        //self.into_inner().into_socket().as_raw()
+        let thing = self.into_inner().into_socket().into_inner();
+        thing
+    }
+}

--- a/library/std/src/os/freertos/io/raw.rs
+++ b/library/std/src/os/freertos/io/raw.rs
@@ -17,15 +17,7 @@ use core::ffi::c_int;
 // RawSocket holds the same state variables as Socket. It is useful as a clone of Socket, which does not call lwip_close
 // when dropped.
 #[stable(feature = "lwip_network", since = "1.64.0")]
-
 pub type RawSocket = c_int;
-/*
-#[derive(Debug, Copy, Clone)]
-pub struct RawSocket {
-    pub socket_handle: c_int, //### TODO: access function for this.
-    pub socket_type: c_int,   //### TODO: access function for this.
-}
-*/
 
 /// Extracts raw sockets.
 #[stable(feature = "lwip_network", since = "1.64.0")]
@@ -36,9 +28,6 @@ pub trait AsRawSocket {
     /// When used in this way, this method does **not** pass ownership of the
     /// raw socket to the caller, and the socket is only guaranteed
     /// to be valid while the original object has not yet been destroyed.
-    ///
-    /// However, borrowing is not strictly required. See [`AsSocket::as_socket`]
-    /// for an API which strictly borrows a socket.
     #[stable(feature = "lwip_network", since = "1.64.0")]
     fn as_raw_socket(&self) -> RawSocket;
 }
@@ -62,9 +51,8 @@ pub trait FromRawSocket {
     ///
     /// The `socket` passed in must:
     ///   - be a valid an open socket,
-    ///   - be a socket that may be freed via [`closesocket`].
-    ///
-    /// [`closesocket`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-closesocket
+    ///   - be a socket that may be freed via lwip_close (achieved by assimilation
+    ///     into a socket type that calls lwip_close on drop())
     #[stable(feature = "lwip_network", since = "1.64.0")]
     unsafe fn from_raw_socket(sock: RawSocket) -> Self;
 }
@@ -113,7 +101,6 @@ impl FromRawSocket for net::TcpStream {
     #[inline]
     unsafe fn from_raw_socket(raw_socket: RawSocket) -> net::TcpStream {
         let sock = Socket::from_raw_socket(raw_socket);
-        //let sock: Socket = sys::net::Socket::from_inner(thing);
         net::TcpStream::from_inner(sys_common::net::TcpStream::from_inner(sock))
     }
 }

--- a/library/std/src/os/freertos/io/raw.rs
+++ b/library/std/src/os/freertos/io/raw.rs
@@ -138,9 +138,7 @@ impl FromRawSocket for net::UdpSocket {
 impl IntoRawSocket for net::TcpStream {
     #[inline]
     fn into_raw_socket(self) -> RawSocket {
-        let thing = self.into_inner().into_socket().into_inner();
-        thing //.into_raw_socket()
-        //self.into_inner().into_socket().as_raw()
+        self.into_inner().into_socket().into_inner()
     }
 }
 
@@ -148,9 +146,7 @@ impl IntoRawSocket for net::TcpStream {
 impl IntoRawSocket for net::TcpListener {
     #[inline]
     fn into_raw_socket(self) -> RawSocket {
-        //self.into_inner().into_socket().as_raw()
-        let thing = self.into_inner().into_socket().into_inner();
-        thing
+        self.into_inner().into_socket().into_inner()
     }
 }
 
@@ -158,8 +154,6 @@ impl IntoRawSocket for net::TcpListener {
 impl IntoRawSocket for net::UdpSocket {
     #[inline]
     fn into_raw_socket(self) -> RawSocket {
-        //self.into_inner().into_socket().as_raw()
-        let thing = self.into_inner().into_socket().into_inner();
-        thing
+        self.into_inner().into_socket().into_inner()
     }
 }

--- a/library/std/src/os/freertos/mod.rs
+++ b/library/std/src/os/freertos/mod.rs
@@ -1,0 +1,4 @@
+//! FreeRTOS-specific definitions
+
+#![stable(feature = "raw_ext", since = "1.1.0")]
+pub mod io;

--- a/library/std/src/os/mod.rs
+++ b/library/std/src/os/mod.rs
@@ -119,6 +119,8 @@ pub mod espidf;
 pub mod fortanix_sgx;
 #[cfg(target_os = "freebsd")]
 pub mod freebsd;
+#[cfg(target_os = "freertos")]
+pub mod freertos;
 #[cfg(target_os = "fuchsia")]
 pub mod fuchsia;
 #[cfg(target_os = "haiku")]

--- a/library/std/src/sys/freertos/net.rs
+++ b/library/std/src/sys/freertos/net.rs
@@ -116,11 +116,9 @@ pub mod netc {
         }
     }
 
-    pub fn send(sock: RawSocket, mem: *const c_void, len: i32, _flags: c_int) -> i32 {
+    pub fn send(sock: RawSocket, mem: *const c_void, len: i32, flags: c_int) -> i32 {
         unsafe {
-            let retval = lwip_send(
-                sock, mem, len, 0, // flags
-            );
+            let retval = lwip_send(sock, mem, len, flags);
 
             retval
         }
@@ -130,7 +128,7 @@ pub mod netc {
         sock: RawSocket,
         mem: *const c_void,
         len: i32,
-        _flags: c_int,
+        flags: c_int,
         to: *const sockaddr,
         tolen: socklen_t,
     ) -> i32 {
@@ -149,10 +147,7 @@ pub mod netc {
         }
         match option {
             SOCK_DGRAM => unsafe {
-                let retval = lwip_sendto(
-                    sock, mem, len, 0, // flags
-                    to, tolen,
-                );
+                let retval = lwip_sendto(sock, mem, len, flags, to, tolen);
 
                 retval
             },

--- a/library/std/src/sys/freertos/net.rs
+++ b/library/std/src/sys/freertos/net.rs
@@ -324,7 +324,7 @@ where
 // Socket implementation
 #[repr(transparent)]
 #[stable(feature = "lwip_network", since = "1.64.0")]
-//#[derive(Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct Socket {
     socket_handle: c_int,
 }
@@ -347,7 +347,6 @@ impl Socket {
         };
 
         let socket_handle = unsafe { lwip_socket(family, socket_type, IPPROTO_IP) };
-        println!("std New socket {:?}", socket_handle);
 
         match socket_handle {
             -1 => Err(io::const_io_error!(io::ErrorKind::Other, "Socket creation failed")),
@@ -868,6 +867,8 @@ impl IntoInner<RawSocket> for Socket {
 impl AsRawSocket for Socket {
     fn as_raw_socket(&self) -> RawSocket {
         let raw_socket = self.as_raw();
+        // We want to drop self without calling the destructor (which closes the socket)
+        // This effectively transfers ownership of the socket to the caller's socket conversion
         forget(self);
         raw_socket
     }

--- a/library/std/src/sys/freertos/net.rs
+++ b/library/std/src/sys/freertos/net.rs
@@ -5,11 +5,15 @@ use crate::io::ErrorKind::*;
 use crate::io::{self, IoSlice, IoSliceMut, Read};
 use crate::mem::size_of;
 use crate::net::{Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr};
+use crate::os::freertos::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket};
+use core::mem::forget;
+
 use crate::ptr;
+use crate::sys;
 use crate::sys::net::netc::*;
 use crate::sys::os::errno;
-use crate::sys::unsupported;
 use crate::sys_common::net::sockaddr_to_addr;
+use crate::sys_common::{AsInner, FromInner, IntoInner};
 use crate::time::{Duration, Instant};
 use core::ffi::{
     c_char, c_int, c_long, c_longlong, c_schar, c_short, c_uchar, c_uint, c_ulonglong, c_ushort,
@@ -27,8 +31,7 @@ pub mod netc {
 
     use crate::mem::size_of;
     use crate::sys::net::RawSocket;
-    use crate::time::Duration;
-    use core::ffi::{c_char, c_int, c_long, c_uint, c_ushort, c_void};
+    use core::ffi::{c_char, c_int, c_void};
 
     // Rust bindings for LwIP TCP/IP stack.
     include!("lwip-rs.rs");
@@ -41,6 +44,11 @@ pub mod netc {
     // This constant not in LwIP Rust bindings, but needed by sys_common\net.rs
     pub const IPV6_MULTICAST_LOOP: i32 = 19; // Not supported in LwIP
 
+    pub fn socket(family: c_int, socket_type: c_int, _protocol: c_int) -> c_int {
+        let socket_handle = unsafe { lwip_socket(family, socket_type, IPPROTO_IP) };
+        socket_handle
+    }
+
     pub fn setsockopt(
         sock: RawSocket,
         level: c_int,
@@ -48,7 +56,7 @@ pub mod netc {
         optval: *const c_void,
         optlen: socklen_t,
     ) -> c_int {
-        let retval = unsafe { lwip_setsockopt(sock.socket_handle, level, optname, optval, optlen) };
+        let retval = unsafe { lwip_setsockopt(sock, level, optname, optval, optlen) };
         match retval {
             0 => 0,
             _ => -1,
@@ -62,7 +70,7 @@ pub mod netc {
         optval: *mut c_void,
         optlen: *mut socklen_t,
     ) -> c_int {
-        let retval = unsafe { lwip_getsockopt(sock.socket_handle, level, optname, optval, optlen) };
+        let retval = unsafe { lwip_getsockopt(sock, level, optname, optval, optlen) };
         match retval {
             0 => 0,
             _ => -1,
@@ -70,8 +78,7 @@ pub mod netc {
     }
 
     pub fn bind(sock: RawSocket, name: *const sockaddr, namelen: socklen_t) -> c_int {
-        let retval =
-            unsafe { lwip_bind(sock.socket_handle, name as *const super::sockaddr, namelen) };
+        let retval = unsafe { lwip_bind(sock, name, namelen) };
         match retval {
             0 => 0,
             _ => -1,
@@ -79,8 +86,7 @@ pub mod netc {
     }
 
     pub fn connect(sock: RawSocket, name: *const sockaddr, namelen: socklen_t) -> c_int {
-        let retval =
-            unsafe { lwip_connect(sock.socket_handle, name as *const super::sockaddr, namelen) };
+        let retval = unsafe { lwip_connect(sock, name, namelen) };
         match retval {
             0 => 0,
             _ => -1,
@@ -88,7 +94,15 @@ pub mod netc {
     }
 
     pub fn listen(sock: RawSocket, backlog: c_int) -> c_int {
-        let retval = unsafe { lwip_listen(sock.socket_handle, backlog) };
+        let retval = unsafe { lwip_listen(sock, backlog) };
+        match retval {
+            0 => 0,
+            _ => -1,
+        }
+    }
+
+    pub fn accept(sock: RawSocket, name: *mut sockaddr, namelen: *mut socklen_t) -> c_int {
+        let retval = unsafe { lwip_accept(sock, name, namelen) };
         match retval {
             0 => 0,
             _ => -1,
@@ -97,18 +111,15 @@ pub mod netc {
 
     pub fn getsockname(sock: RawSocket, name: *mut sockaddr, namelen: *mut socklen_t) -> c_int {
         unsafe {
-            let retval = lwip_getsockname(sock.socket_handle, name, namelen);
+            let retval = lwip_getsockname(sock, name, namelen);
             retval
         }
     }
 
-    pub fn send(sock: RawSocket, mem: *const c_void, len: i32, flags: c_int) -> i32 {
+    pub fn send(sock: RawSocket, mem: *const c_void, len: i32, _flags: c_int) -> i32 {
         unsafe {
             let retval = lwip_send(
-                sock.socket_handle,
-                mem,
-                len,
-                0, // flags
+                sock, mem, len, 0, // flags
             );
 
             retval
@@ -119,19 +130,28 @@ pub mod netc {
         sock: RawSocket,
         mem: *const c_void,
         len: i32,
-        flags: c_int,
+        _flags: c_int,
         to: *const sockaddr,
         tolen: socklen_t,
     ) -> i32 {
-        match sock.socket_type {
+        // Get the socket type using getsockopt
+        let mut option: c_int = 0;
+        let mut option_len = size_of::<c_int>() as socklen_t;
+        let retval: c_int = getsockopt(
+            sock,
+            SOL_SOCKET,
+            SO_TYPE,
+            &mut option as *mut _ as *mut c_void,
+            &mut option_len,
+        );
+        if retval == -1 {
+            return -1;
+        }
+        match option {
             SOCK_DGRAM => unsafe {
                 let retval = lwip_sendto(
-                    sock.socket_handle,
-                    mem,
-                    len,
-                    0, // flags
-                    to as *const super::sockaddr,
-                    tolen,
+                    sock, mem, len, 0, // flags
+                    to, tolen,
                 );
 
                 retval
@@ -143,8 +163,13 @@ pub mod netc {
         }
     }
 
+    pub fn sendmsg(sock: RawSocket, message: *const msghdr, flags: c_int) -> i32 {
+        let retval = unsafe { lwip_sendmsg(sock, message, flags) };
+        retval
+    }
+
     pub fn recv(sock: RawSocket, mem: *mut c_void, len: i32, flags: c_int) -> i32 {
-        let retval = unsafe { lwip_recv(sock.socket_handle, mem, len as size_t, flags) };
+        let retval = unsafe { lwip_recv(sock, mem, len as size_t, flags) };
 
         retval
     }
@@ -157,18 +182,23 @@ pub mod netc {
         from: *mut sockaddr,
         fromlen: *mut socklen_t,
     ) -> i32 {
-        match sock.socket_type {
+        // Get the socket type using getsockopt
+        let mut option: c_int = 0;
+        let mut option_len = size_of::<c_int>() as socklen_t;
+        let retval: c_int = getsockopt(
+            sock,
+            SOL_SOCKET,
+            SO_TYPE,
+            &mut option as *mut _ as *mut c_void,
+            &mut option_len,
+        );
+        if retval == -1 {
+            return -1;
+        }
+        match option {
             SOCK_DGRAM => {
-                let retval = unsafe {
-                    lwip_recvfrom(
-                        sock.socket_handle,
-                        mem,
-                        len as size_t,
-                        flags,
-                        from as *mut super::sockaddr,
-                        fromlen,
-                    )
-                };
+                let retval =
+                    unsafe { lwip_recvfrom(sock, mem, len as size_t, flags, from, fromlen) };
 
                 retval
             }
@@ -179,9 +209,14 @@ pub mod netc {
         }
     }
 
+    pub fn recvmsg(sock: RawSocket, message: *mut msghdr, flags: c_int) -> i32 {
+        let retval = unsafe { lwip_recvmsg(sock, message, flags) };
+        retval
+    }
+
     pub fn getpeername(sock: RawSocket, name: *mut sockaddr, namelen: *mut socklen_t) -> c_int {
         unsafe {
-            let retval = lwip_getpeername(sock.socket_handle, name, namelen);
+            let retval = lwip_getpeername(sock, name, namelen);
             retval
         }
     }
@@ -204,6 +239,26 @@ pub mod netc {
         // Crude check that the interface is up by seeing if an IP address has been assigned.
         // Unfortunately, LwIP does not provide a clean API function to do this.
         unsafe { gnetif.ip_addr.addr != 0 }
+    }
+
+    pub fn shutdown(sock: RawSocket, how: c_int) -> i32 {
+        let retval = unsafe { lwip_shutdown(sock, how) };
+        retval
+    }
+
+    pub fn poll(fds: *const pollfd, nfds: nfds_t, timeout: core::ffi::c_int) -> i32 {
+        let retval = unsafe { lwip_poll(fds, nfds, timeout) };
+        retval
+    }
+
+    pub fn fcntl(s: core::ffi::c_int, cmd: core::ffi::c_int, val: core::ffi::c_int) -> i32 {
+        let retval = unsafe { lwip_fcntl(s, cmd, val) };
+        retval
+    }
+
+    pub fn ioctl(s: core::ffi::c_int, cmd: core::ffi::c_long, argp: *mut core::ffi::c_void) -> i32 {
+        let retval = unsafe { lwip_ioctl(s, cmd, argp) };
+        retval
     }
 }
 //###########################################################################################################################
@@ -267,11 +322,11 @@ where
 }
 
 // Socket implementation
+#[repr(transparent)]
 #[stable(feature = "lwip_network", since = "1.64.0")]
-#[derive(Debug, Clone)]
+//#[derive(Debug, Clone)]
 pub struct Socket {
     socket_handle: c_int,
-    socket_type: c_int,
 }
 
 // This must match the timeval C definition
@@ -292,11 +347,12 @@ impl Socket {
         };
 
         let socket_handle = unsafe { lwip_socket(family, socket_type, IPPROTO_IP) };
+        println!("std New socket {:?}", socket_handle);
 
         match socket_handle {
             -1 => Err(io::const_io_error!(io::ErrorKind::Other, "Socket creation failed")),
             _ => {
-                let socket = Socket { socket_handle: socket_handle, socket_type: socket_type };
+                let socket = Socket { socket_handle: socket_handle };
                 Ok(socket)
             }
         }
@@ -346,6 +402,23 @@ impl Socket {
             ));
         }
 
+        //Get the socket type, in case we need to reopen the socket during timeout period.
+        let mut socket_type: c_int = 0;
+        let mut option_len = size_of::<c_int>() as socklen_t;
+        let retval: c_int = netc::getsockopt(
+            self.as_raw(),
+            netc::SOL_SOCKET,
+            netc::SO_TYPE,
+            &mut socket_type as *mut _ as *mut c_void,
+            &mut option_len,
+        );
+        if retval == -1 {
+            return Err(io::const_io_error!(
+                io::ErrorKind::InvalidInput,
+                "Cannot determine socket type",
+            ));
+        }
+
         let start = Instant::now();
 
         loop {
@@ -376,11 +449,8 @@ impl Socket {
                 // If connect is in progress (as expected), we wait for the duration of the timeout and check progress.
                 -1 => {
                     if errno() == EINPROGRESS {
-                        let mut fds = pollfd {
-                            fd: self.as_raw().socket_handle,
-                            events: POLLIN | POLLOUT,
-                            revents: 0,
-                        };
+                        let mut fds =
+                            pollfd { fd: self.as_raw(), events: POLLIN | POLLOUT, revents: 0 };
 
                         // lwip_poll will return 1 on successful connection, or 0 if the timeout occurs before any response
 
@@ -405,7 +475,7 @@ impl Socket {
                                     // to call lwip_connect again
                                     let retval = unsafe { lwip_close(self.socket_handle) };
                                     let socket_handle = unsafe {
-                                        lwip_socket(netc::AF_INET, self.socket_type, IPPROTO_IP)
+                                        lwip_socket(netc::AF_INET, socket_type, IPPROTO_IP)
                                     };
                                     match socket_handle {
                                         -1 => {
@@ -476,7 +546,7 @@ impl Socket {
         match socket_handle {
             -1 => Err(io::const_io_error!(io::ErrorKind::Other, "accept failed")),
             _ => {
-                let socket = Socket { socket_handle: socket_handle, socket_type: self.socket_type };
+                let socket = Socket { socket_handle: socket_handle };
                 Ok(socket)
             }
         }
@@ -484,7 +554,8 @@ impl Socket {
 
     #[stable(feature = "lwip_network", since = "1.64.0")]
     pub fn duplicate(&self) -> io::Result<Socket> {
-        Ok(self.clone())
+        let socket = Socket { socket_handle: self.socket_handle };
+        Ok(socket)
     }
 
     fn recv_with_flags(&self, buf: &mut [u8], flags: c_int) -> io::Result<usize> {
@@ -748,8 +819,7 @@ impl Socket {
     // Here, we provide a clone of the Socket struct, which does not call lwip_close when dropped.
     #[stable(feature = "lwip_network", since = "1.64.0")]
     pub fn as_raw(&self) -> RawSocket {
-        let mut raw_socket =
-            RawSocket { socket_handle: self.socket_handle, socket_type: self.socket_type };
+        let mut raw_socket = self.socket_handle;
         raw_socket
     }
 }
@@ -773,11 +843,46 @@ impl Drop for Socket {
     }
 }
 
-// RawSocket holds the same state variables as Socket. It is used as a clone of Socket, which does not call lwip_close
-// when dropped.
 #[stable(feature = "lwip_network", since = "1.64.0")]
-#[derive(Debug, Copy, Clone)]
-pub struct RawSocket {
-    socket_handle: c_int,
-    socket_type: c_int,
+impl AsInner<RawSocket> for Socket {
+    fn as_inner(&self) -> &RawSocket {
+        &self.socket_handle
+    }
+}
+
+#[stable(feature = "lwip_network", since = "1.64.0")]
+impl FromInner<RawSocket> for Socket {
+    fn from_inner(sock: RawSocket) -> Socket {
+        Socket { socket_handle: sock }
+    }
+}
+
+#[stable(feature = "lwip_network", since = "1.64.0")]
+impl IntoInner<RawSocket> for Socket {
+    fn into_inner(self) -> RawSocket {
+        self.socket_handle as RawSocket
+    }
+}
+
+#[stable(feature = "lwip_network", since = "1.64.0")]
+impl AsRawSocket for Socket {
+    fn as_raw_socket(&self) -> RawSocket {
+        let raw_socket = self.as_raw();
+        forget(self);
+        raw_socket
+    }
+}
+
+#[stable(feature = "lwip_network", since = "1.64.0")]
+impl IntoRawSocket for Socket {
+    fn into_raw_socket(self) -> RawSocket {
+        self.into_raw_socket()
+    }
+}
+
+#[stable(feature = "lwip_network", since = "1.64.0")]
+impl FromRawSocket for Socket {
+    unsafe fn from_raw_socket(raw_socket: RawSocket) -> Self {
+        Self { socket_handle: raw_socket }
+    }
 }


### PR DESCRIPTION
RawSocket simplified to comprise solely a socket handle (makes it easier for other parts of the code)
RawSocket moved to OS-specific IO module to allow external access (needed for socket2)
Added some missing socket functions (needed by socket2, but not be std net internally)
Added RawSocket to/from conversions to help with Socket2's conversion and ownership transfer.