### PR TITLE
Feature/mvpn 2204 fixes for socket2

### DIFF
--- a/library/std/src/sys/freertos/lwip-rs.rs
+++ b/library/std/src/sys/freertos/lwip-rs.rs
@@ -867,6 +867,13 @@ pub const TCP_KEEPIDLE: core::ffi::c_int = 3;
 pub const TCP_KEEPINTVL: core::ffi::c_int = 4;
 pub const TCP_KEEPCNT: core::ffi::c_int = 5;
 pub const FIONBIO: core::ffi::c_long = -2147195266;
+pub const F_GETFL: core::ffi::c_int = 3;
+pub const F_SETFL: core::ffi::c_int = 4;
+pub const O_NONBLOCK: core::ffi::c_int = 1;
+pub const O_NDELAY: core::ffi::c_int = 1;
+pub const O_RDONLY: core::ffi::c_int = 2;
+pub const O_WRONLY: core::ffi::c_int = 4;
+pub const O_RDWR: core::ffi::c_int = 6;
 pub const SHUT_RD: core::ffi::c_int = 0;
 pub const SHUT_WR: core::ffi::c_int = 1;
 pub const SHUT_RDWR: core::ffi::c_int = 2;
@@ -874,6 +881,7 @@ pub const POLLIN: i16 = 1;
 pub const POLLOUT: i16 = 2;
 pub const POLLERR: i16 = 4;
 pub const POLLNVAL: i16 = 8;
+pub const POLLHUP: i16 = 512;
 pub const IPV6_CHECKSUM: core::ffi::c_int = 7;
 pub const IPV6_V6ONLY: core::ffi::c_int = 27;
 pub const IP_MULTICAST_TTL: core::ffi::c_int = 5;
@@ -959,19 +967,19 @@ fn bindgen_test_layout_pollfd() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timeval {
-    pub tv_sec: core::ffi::c_long,
+    pub tv_sec: core::ffi::c_longlong,
     pub tv_usec: core::ffi::c_long,
 }
 #[test]
 fn bindgen_test_layout_timeval() {
     assert_eq!(
         ::core::mem::size_of::<timeval>(),
-        8usize,
+        16usize,
         concat!("Size of: ", stringify!(timeval))
     );
     assert_eq!(
         ::core::mem::align_of::<timeval>(),
-        4usize,
+        8usize,
         concat!("Alignment of ", stringify!(timeval))
     );
     fn test_field_tv_sec() {
@@ -998,7 +1006,7 @@ fn bindgen_test_layout_timeval() {
                 let ptr = uninit.as_ptr();
                 ::core::ptr::addr_of!((*ptr).tv_usec) as usize - ptr as usize
             },
-            4usize,
+            8usize,
             concat!(
                 "Offset of field: ",
                 stringify!(timeval),
@@ -1152,6 +1160,8 @@ fn bindgen_test_layout_msghdr() {
     }
     test_field_msg_flags();
 }
+pub const MSG_TRUNC: core::ffi::c_int = 4;
+pub const MSG_CTRUNC: core::ffi::c_int = 8;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct netif {

--- a/library/std/src/sys/freertos/net.rs
+++ b/library/std/src/sys/freertos/net.rs
@@ -117,8 +117,7 @@ pub mod netc {
     }
 
     pub fn send(sock: RawSocket, mem: *const c_void, len: i32, flags: c_int) -> i32 {
-        let retval = unsafe { lwip_send(sock, mem, len, flags) };
-        retval
+        unsafe { lwip_send(sock, mem, len, flags) }
     }
 
     pub fn sendto(
@@ -131,19 +130,15 @@ pub mod netc {
     ) -> i32 {
         // Call lwip_sendto regardless of socket type. It will return an error for invalid combinations.
         // Previously only SOCK_DGRAM was supported, but we also need raw socket support.
-        let retval = unsafe { lwip_sendto(sock, mem, len, flags, to, tolen) };
-        retval
+        unsafe { lwip_sendto(sock, mem, len, flags, to, tolen) }
     }
 
     pub fn sendmsg(sock: RawSocket, message: *const msghdr, flags: c_int) -> i32 {
-        let retval = unsafe { lwip_sendmsg(sock, message, flags) };
-        retval
+        unsafe { lwip_sendmsg(sock, message, flags) }
     }
 
     pub fn recv(sock: RawSocket, mem: *mut c_void, len: i32, flags: c_int) -> i32 {
-        let retval = unsafe { lwip_recv(sock, mem, len as size_t, flags) };
-
-        retval
+        unsafe { lwip_recv(sock, mem, len as size_t, flags) }
     }
 
     pub fn recvfrom(
@@ -156,20 +151,15 @@ pub mod netc {
     ) -> i32 {
         // Call lwip_recvfrom regardless of socket type. It will return an error for invalid combinations.
         // Previously only SOCK_DGRAM was supported, but we also need raw socket support.
-        let retval = unsafe { lwip_recvfrom(sock, mem, len as size_t, flags, from, fromlen) };
-        retval
+        unsafe { lwip_recvfrom(sock, mem, len as size_t, flags, from, fromlen) }
     }
 
     pub fn recvmsg(sock: RawSocket, message: *mut msghdr, flags: c_int) -> i32 {
-        let retval = unsafe { lwip_recvmsg(sock, message, flags) };
-        retval
+        unsafe { lwip_recvmsg(sock, message, flags) }
     }
 
     pub fn getpeername(sock: RawSocket, name: *mut sockaddr, namelen: *mut socklen_t) -> c_int {
-        unsafe {
-            let retval = lwip_getpeername(sock, name, namelen);
-            retval
-        }
+        unsafe { lwip_getpeername(sock, name, namelen) }
     }
 
     pub fn getaddrinfo(
@@ -178,8 +168,7 @@ pub mod netc {
         hints: *const addrinfo,
         res: *mut *mut addrinfo,
     ) -> c_int {
-        let retval = unsafe { lwip_getaddrinfo(nodename, servname, hints, res) };
-        retval
+        unsafe { lwip_getaddrinfo(nodename, servname, hints, res) }
     }
 
     pub fn freeaddrinfo(ai: *mut addrinfo) {
@@ -193,23 +182,19 @@ pub mod netc {
     }
 
     pub fn shutdown(sock: RawSocket, how: c_int) -> i32 {
-        let retval = unsafe { lwip_shutdown(sock, how) };
-        retval
+        unsafe { lwip_shutdown(sock, how) }
     }
 
     pub fn poll(fds: *const pollfd, nfds: nfds_t, timeout: core::ffi::c_int) -> i32 {
-        let retval = unsafe { lwip_poll(fds, nfds, timeout) };
-        retval
+        unsafe { lwip_poll(fds, nfds, timeout) }
     }
 
     pub fn fcntl(s: core::ffi::c_int, cmd: core::ffi::c_int, val: core::ffi::c_int) -> i32 {
-        let retval = unsafe { lwip_fcntl(s, cmd, val) };
-        retval
+        unsafe { lwip_fcntl(s, cmd, val) }
     }
 
     pub fn ioctl(s: core::ffi::c_int, cmd: core::ffi::c_long, argp: *mut core::ffi::c_void) -> i32 {
-        let retval = unsafe { lwip_ioctl(s, cmd, argp) };
-        retval
+        unsafe { lwip_ioctl(s, cmd, argp) }
     }
 }
 //###########################################################################################################################


### PR DESCRIPTION
LwIP binding changes for consistency with lwip crate to add extra definitions and fix timeval struct.
Fixes for raw sockets to allow other than protocol IPPROTO_IP in new socket creation and SOCK_DGRAM for sendto/recvfrom.